### PR TITLE
Implement support for key revision.tag=last

### DIFF
--- a/docs/revision-branch.md
+++ b/docs/revision-branch.md
@@ -1,0 +1,32 @@
+# Revision: branch
+
+If you want to specify the cloning an dupdating of a git repo based on a git branch you can define it with the following syntax.
+
+```yaml
+repos:
+  pykwalify:
+    clone-url: git@github.com:Grokzen/pykwalify.git
+    revision:
+      branch: master
+```
+
+This will clone the git repo and for each `sgit update` you make after the intiail clone, it will do a `git pull` on the given branch to move your clone to the latest commit on this branch.
+
+In the case you change the branch to a new one, it will fetch the latest commits for that other branch and do a `git checkout` of it locally.
+
+
+## CLI
+
+There is a subcommand `sgit repo set` that is used to update the branch for a given repo.
+
+Example syntax
+
+```
+# Update to branch unstable
+sgit repo set pykwalify branch unstable
+
+# Update cloned git repo to this new branch
+sgit update
+```
+
+In the case you have defined a branch that do not exists on the `origin remote` then you will get an error when running `sgit update`. No checks is done at the time you set your branch.

--- a/docs/revision-branch.md
+++ b/docs/revision-branch.md
@@ -1,6 +1,6 @@
 # Revision: branch
 
-If you want to specify the cloning an dupdating of a git repo based on a git branch you can define it with the following syntax.
+If you want to specify the cloning and updating of a git repo based on a git branch you can define it with the following syntax.
 
 ```yaml
 repos:
@@ -10,9 +10,9 @@ repos:
       branch: master
 ```
 
-This will clone the git repo and for each `sgit update` you make after the intiail clone, it will do a `git pull` on the given branch to move your clone to the latest commit on this branch.
+This will clone the git repo and for each `sgit update` you make after the initial clone, it will do a git pull on the given branch to move your clone to the latest commit on this branch.
 
-In the case you change the branch to a new one, it will fetch the latest commits for that other branch and do a `git checkout` of it locally.
+In the case you change the branch to a new one, it will fetch the latest commits for that other branch and do a git checkout of it locally.
 
 
 ## CLI

--- a/docs/revision-tag.md
+++ b/docs/revision-tag.md
@@ -173,6 +173,6 @@ sgit repo set pykwalify tag latest
 sgit update
 
 # If you want the additional options with "tag-filter-regex", "tag-clean-regex" and "tag-order"
-# you must add them manually and then update your clone with
+# you must add them manually to your .sgit.yml config file and then update your clone with
 sgit update
 ```

--- a/docs/revision-tag.md
+++ b/docs/revision-tag.md
@@ -1,6 +1,6 @@
 # Revision: tag
 
-If you want to use the more specialized and advance option for parsing and selecting a specific tag from a git repo then you should use the tag revision option.
+If you want to use the more specialized and advanced option for parsing and selecting a specific tag from a git repo then you should use the tag revision option.
 
 This is the following syntax and extra options. More detailed examples is further down in this document.
 
@@ -20,7 +20,7 @@ repos:
       # Pre-processes the tags before selection step. Create a regex with a group that you want
       # to extract the semver data from. Multiple regex values is supported but first value matching
       # will be used before moving on to next tag.
-      # This step is usefull to remove and prefix or suffixes from tags and only care about the semver part when comparing tags
+      # This step is useful to remove any prefix or suffix from tags, only affecting the semver part when comparing tags
       tag-clean-regex:
         # Run regex.match() to extract out value if possible, otherwise keep it
         - "v([0-9].[0-9].[0-9])"

--- a/docs/revision-tag.md
+++ b/docs/revision-tag.md
@@ -1,0 +1,178 @@
+# Revision: tag
+
+If you want to use the more specialized and advance option for parsing and selecting a specific tag from a git repo then you should use the tag revision option.
+
+This is the following syntax and extra options. More detailed examples is further down in this document.
+
+```yaml
+repos:
+  pykwalify:
+    clone-url: git@github.com:Grokzen/pykwalify.git
+    revision:
+      tag: latest
+
+      # Pre-processes the tags before matching and removes any that we do not want
+      # This step runs before clean step.
+      # Multiple regex values is supported but it will stop parsing at first match and remove it
+      tag-filter-regex:
+        - "([0-9].[0-9].[0-9])"
+
+      # Pre-processes the tags before selection step. Create a regex with a group that you want
+      # to extract the semver data from. Multiple regex values is supported but first value matching
+      # will be used before moving on to next tag.
+      # This step is usefull to remove and prefix or suffixes from tags and only care about the semver part when comparing tags
+      tag-clean-regex:
+        # Run regex.match() to extract out value if possible, otherwise keep it
+        - "v([0-9].[0-9].[0-9])"
+
+      # Selection step after filter and clean steps
+      # semver order is default, choose one of them in your config
+      # Ignore tag order, will parse for latest version based on semver
+      tag-order: semver
+
+      # Ignores semver, will order tags by timestamp and take latest tag
+      tag-order: time
+```
+
+
+## Examples
+
+Basic example. This will default to parsing semver of all tags and pick the highest semver version
+
+```yaml
+# .sgit.yml
+repos:
+  pykwalify:
+    clone-url: git@github.com:Grokzen/pykwalify.git
+    revision:
+      tag: latest
+
+# Tags list
+1.0.0
+0.9.0
+0.8.0
+
+# Selected tag
+1.0.0
+```
+
+This example will ignore the semver and order all tags by time and pick the last one
+
+```yaml
+# .sgit.yml
+repos:
+  pykwalify:
+    clone-url: git@github.com:Grokzen/pykwalify.git
+    revision:
+      tag: latest
+      tag-order: time
+
+# Tags list
+0.9.0
+1.0.0
+0.8.0
+
+# Selected tag
+0.9.0
+```
+
+In this example we will filter out v1.0.0 as that is an unwanted tag format and we do not desire in our
+parsing for the latest tag. It will default to semver comparison and select the latest version 0.9.0
+
+```yaml
+# .sgit.yml
+repos:
+  pykwalify:
+    clone-url: git@github.com:Grokzen/pykwalify.git
+    revision:
+      tag: latest
+      # Filter out unwanted tags based on regex match and grouping.
+      # This feature works as a whitelist for what tags we want to keep
+      # Multiple list values is supported
+      tag-filter-regex:
+        - "([0-9].[0-9].[0-9])"
+
+# Tags list
+v1.0.0
+0.9.0
+0.8.0
+
+# Selected tag
+0.9.0
+```
+
+In this example we want to have the latest version based on semver comparison. It will extract out the semver version
+from all tags based on the regex and then do a semver comparison on the result list of items.
+
+```yaml
+# .sgit.yml
+repos:
+  pykwalify:
+    clone-url: git@github.com:Grokzen/pykwalify.git
+    revision:
+      tag: latest
+      # Filter out unwanted tags based on regex match and grouping
+      tag-clean-regex:
+        - "v([0-9].[0-9].[0-9])"
+
+# Tags list
+v1.0.0
+0.9.0
+v0.8.0
+
+# Selected tag
+1.0.0
+```
+
+When using both filter and clean we will filter before cleaning. In this example it will first remove all tags
+that starts with `v` and any version that is not a 3 group semver version.
+
+```yaml
+# .sgit.yml
+repos:
+  pykwalify:
+    clone-url: git@github.com:Grokzen/pykwalify.git
+    revision:
+      tag: latest
+      # This will run before clean and 
+      tag-filter-regex:
+        - "([0-9].[0-9].[0-9])"
+      # Filter out unwanted tags based on regex match and grouping
+      tag-clean-regex:
+        - "v([0-9].[0-9].[0-9])"
+
+# Tags list
+v1.0.0
+0.9.0
+v0.8.0
+15.10
+
+# Selected tag
+0.9.0
+```
+
+
+## CLI
+
+Currently you can only set the `revision.tag` key from cli. The extra options have to be added
+manually to your configuration file and is not possible to set from cli.
+
+Example how to change from a branch to a tag with one repo
+
+```yaml
+# Init new repo
+sgit init
+
+# Add a new git repo, this defaults to revision.branch=master
+sgit repo add pykwalify git@github.com:Grokzen/pykwalify.git master
+
+# To update and set a specific tag
+sgit repo set pykwalify tag latest
+
+# Update your clone to point to the tag
+sgit update
+
+# If you want the additional options with "tag-filter-regex", "tag-clean-regex" and "tag-order"
+# you must add them manually and then update your clone with
+sgit update
+```

--- a/docs/revision-tag.md
+++ b/docs/revision-tag.md
@@ -9,35 +9,65 @@ repos:
   pykwalify:
     clone-url: git@github.com:Grokzen/pykwalify.git
     revision:
-      tag: latest
+      tag:
+        # One regex string or a list of regex strings is supported here
+        # Filter is the first step and the purpose is two fold where one
+        # is that you want to filter out a specific set of tags based on a pattern matching.
+        # The second feature is that if you make a regex match group you can extract out
+        # any value from within the string in case you need to clean away unwanted data.
+        # A common case is that semver tags is named v1.0.0 where we only want 1.0.0 to perform
+        # a semver comparison against. For a good example where this is very usefull please check
+        # the azure-python-sdk git mono repo.
+        # If filter key is not present or is an empty string or empty list all values
+        # will be preserved in the output.
+        filter: "my-sdk-[0-9].[0-9].[0-9]"
 
-      # Pre-processes the tags before matching and removes any that we do not want
-      # This step runs before clean step.
-      # Multiple regex values is supported but it will stop parsing at first match and remove it
-      tag-filter-regex:
-        - "([0-9].[0-9].[0-9])"
+        # Or in list form with multiple values. With multiple values, any value that wants to be preserved must match
+        # at least one of them, but not all of them. This is considred a whitelist & extract operation.
+        filter:
+          - "([0-9].[0-9].[0-9])"
+          - "v([0-9].[0-9].[0-9])"
 
-      # Pre-processes the tags before selection step. Create a regex with a group that you want
-      # to extract the semver data from. Multiple regex values is supported but first value matching
-      # will be used before moving on to next tag.
-      # This step is useful to remove any prefix or suffix from tags, only affecting the semver part when comparing tags
-      tag-clean-regex:
-        # Run regex.match() to extract out value if possible, otherwise keep it
-        - "v([0-9].[0-9].[0-9])"
+        # Second step is to order the output from the filter step. In most cases the default semver
+        # ordering is what you want by default. How to think about it is that if you order something
+        # you will order the "top" or latest item to the right and the lower items to the
+        # left or begining of a list.
+        # If you order ["1.0.0", "1.1.0", "0.9.0"] it will semver sort to ["0.9.0", "1.0.0", "1.1.0"]
+        # This means that if you later on in the selection stage choose "last" or "first" special keywords,
+        # you will get the first or last item in the output list from this step.
+        # If you order it by time, for tags it will look only at the timestamp of when the tag
+        # was created and ignores the semver version or the content of the tag string.
+        # Alphabetical ordering will simply sort all items based on their string content only.
+        # Order defaults to semver
+        order: "semver|time|alphabetical"
 
-      # Selection step after filter and clean steps
-      # semver order is default, choose one of them in your config
-      # Ignore tag order, will parse for latest version based on semver
-      tag-order: semver
+        # Last step is to select one item out from the output from the order step.
+        # Two special keywords exists, "first" and "last". They will pick the first or last item from the list
+        # of items from the order step. In the most common case for simple git repos, you want to select the last
+        # tag from any tag in the git repo as they only make tags on their master branch and only sequential version increases.
+        # This will not work in cases like big shared mono repos with tags for different components where if you do not
+        # filter out what you want properly, you will get the latest tag for a random component which might be wrong for
+        # your needs
+        # By default the selection method will be semver comparison defined by PEP440. This mean you can do selections
+        # with >, <, >=, <=, == etc to select out the version you want. Note here that if your selection matches multiple
+        # versions, it will take the last item in the list by default.
+        select: ">=1.0.0"
 
-      # Ignores semver, will order tags by timestamp and take latest tag
-      tag-order: time
+        # Select supports child arguments in the following format. This makes it possible to change some of the parameters
+        # in the selection method to be either SEMVER or EXACT. EXACT means that you make a plain string comparison
+        # between what you specify in the "value" field and what you have in your input list. This is equal to
+        # "if str_a == str_b" and the first match will be the returned item. If you have no match it will fail out
+        # as the selection you want do not exists. EXACT option should be chosen if you care less about semver and want
+        # to ignore filters and order and do more plain string selection.
+        select:
+          value: "abc-1.0.0"
+          method: "exact"
 ```
 
 
 ## Examples
 
-Basic example. This will default to parsing semver of all tags and pick the highest semver version
+Basic example. This example will not filter out any items, it will order them by semver and the selection want the latest tag based on semver comparison. This will result in `1.0.0` as the output when doing `sgit update`
 
 ```yaml
 # .sgit.yml
@@ -45,7 +75,8 @@ repos:
   pykwalify:
     clone-url: git@github.com:Grokzen/pykwalify.git
     revision:
-      tag: latest
+      tag:
+        select: last
 
 # Tags list
 1.0.0
@@ -56,7 +87,7 @@ repos:
 1.0.0
 ```
 
-This example will ignore the semver and order all tags by time and pick the last one
+This example will ignore the semver and order all tags by time and pick the last one. Note this example is not super realistic as the ordering based on the semver looks wrong. But in this case we are working with git-flow model and we have support branches where old minor version tags can be created after new:er releases have been done. Time ordering is more suited for single release branch repos and not git-flow model git repos.
 
 ```yaml
 # .sgit.yml
@@ -64,20 +95,21 @@ repos:
   pykwalify:
     clone-url: git@github.com:Grokzen/pykwalify.git
     revision:
-      tag: latest
-      tag-order: time
+      tag:
+        order: time
+        select: last
 
 # Tags list
-0.9.0
-1.0.0
-0.8.0
+1.0.0 (created 2021-01-01)
+0.8.1 (created 2022-12-01)
+0.8.0 (created 2020-01-01)
 
 # Selected tag
-0.9.0
+0.8.1
 ```
 
 In this example we will filter out v1.0.0 as that is an unwanted tag format and we do not desire in our
-parsing for the latest tag. It will default to semver comparison and select the latest version 0.9.0
+parsing for the latest tag. It will default to semver comparison and select the latest version 0.9.0.
 
 ```yaml
 # .sgit.yml
@@ -85,12 +117,12 @@ repos:
   pykwalify:
     clone-url: git@github.com:Grokzen/pykwalify.git
     revision:
-      tag: latest
-      # Filter out unwanted tags based on regex match and grouping.
-      # This feature works as a whitelist for what tags we want to keep
-      # Multiple list values is supported
-      tag-filter-regex:
-        - "([0-9].[0-9].[0-9])"
+      tag:
+        # Filter out unwanted tags based on regex match and grouping.
+        # This feature works as a whitelist for what tags we want to keep
+        # Multiple list values is supported
+        filter: "([0-9].[0-9].[0-9])"
+        select: "last"
 
 # Tags list
 v1.0.0
@@ -101,8 +133,7 @@ v1.0.0
 0.9.0
 ```
 
-In this example we want to have the latest version based on semver comparison. It will extract out the semver version
-from all tags based on the regex and then do a semver comparison on the result list of items.
+In this example we want to have the latest semver version. It will extract out the semver version from all tags based on the regex and then do a semver comparison on the result list of items.
 
 ```yaml
 # .sgit.yml
@@ -110,10 +141,12 @@ repos:
   pykwalify:
     clone-url: git@github.com:Grokzen/pykwalify.git
     revision:
-      tag: latest
-      # Filter out unwanted tags based on regex match and grouping
-      tag-clean-regex:
-        - "v([0-9].[0-9].[0-9])"
+      tag:
+        # Filter out the "v" from some tags, and keep the regular semver tags
+        filter:
+          - "[0-9].[0-9].[0-9]"
+          - "v([0-9].[0-9].[0-9])"
+        select: "last"
 
 # Tags list
 v1.0.0
@@ -124,8 +157,7 @@ v0.8.0
 1.0.0
 ```
 
-When using both filter and clean we will filter before cleaning. In this example it will first remove all tags
-that starts with `v` and any version that is not a 3 group semver version.
+In this example we can limit the version we want to select to a older tag based on semver comparison.
 
 ```yaml
 # .sgit.yml
@@ -133,46 +165,14 @@ repos:
   pykwalify:
     clone-url: git@github.com:Grokzen/pykwalify.git
     revision:
-      tag: latest
-      # This will run before clean and 
-      tag-filter-regex:
-        - "([0-9].[0-9].[0-9])"
-      # Filter out unwanted tags based on regex match and grouping
-      tag-clean-regex:
-        - "v([0-9].[0-9].[0-9])"
+      tag:
+        select: "<1.0.0"
 
 # Tags list
-v1.0.0
+1.0.0
 0.9.0
-v0.8.0
-15.10
+0.8.0
 
 # Selected tag
 0.9.0
-```
-
-
-## CLI
-
-Currently you can only set the `revision.tag` key from cli. The extra options have to be added
-manually to your configuration file and is not possible to set from cli.
-
-Example how to change from a branch to a tag with one repo
-
-```yaml
-# Init new repo
-sgit init
-
-# Add a new git repo, this defaults to revision.branch=master
-sgit repo add pykwalify git@github.com:Grokzen/pykwalify.git master
-
-# To update and set a specific tag
-sgit repo set pykwalify tag latest
-
-# Update your clone to point to the tag
-sgit update
-
-# If you want the additional options with "tag-filter-regex", "tag-clean-regex" and "tag-order"
-# you must add them manually to your .sgit.yml config file and then update your clone with
-sgit update
 ```

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
         "docopt>=0.6.2",
         "ruamel.yaml>=0.16.0",
         "gitpython>=3.1.0",
+        "semver==3.0.0.dev3",
     ],
     python_requires=">=3.6",
     extras_require={
@@ -36,6 +37,8 @@ setup(
         ],
         "dev": [
             "pylint",
+            "ptpython",
+            "ptpdb",
         ],
     },
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,9 @@ setup(
             "ptpython",
             "ptpdb",
         ],
+        "validation": [
+            "pykwalify",
+        ]
     },
     classifiers=[
         # "Development Status :: 1 - Planning",

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
         "docopt>=0.6.2",
         "ruamel.yaml>=0.16.0",
         "gitpython>=3.1.0",
-        "semver==3.0.0.dev3",
+        "packaging>=21.3",
     ],
     python_requires=">=3.6",
     extras_require={

--- a/sgit/constants.py
+++ b/sgit/constants.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+
+DEFAULT_REPO_CONTENT = "repos: { }\n"
+
+__all__ = [
+    "DEFAULT_REPO_CONTENT",
+]

--- a/sgit/core.py
+++ b/sgit/core.py
@@ -608,7 +608,6 @@ class Sgit():
             ordered_sequence = list(
                 sorted(
                     sequence,
-                    # reverse=True,
                     key=lambda x: version.Version(x)
                 )
             )
@@ -621,13 +620,15 @@ class Sgit():
             ordered_sequence = list(
                 sorted(
                     sequence,
-                    # reverse=True,
                     key=lambda t: t[1],
                 )
             )
         elif method == OrderAlgorithms.ALPHABETICAL:
             print(f"DEBUG: Order sequence of items by ALPHABETICAL string order")
             print(sequence)
+
+            # By default sorted will do alphabetical sort
+            ordered_sequence = list(sorted(sequence))
         else:
             raise SgitConfigException(f"Unsupported ordering algorithm selected")
 

--- a/sgit/core.py
+++ b/sgit/core.py
@@ -499,8 +499,11 @@ class Sgit():
                     #
                     # Main tag parsing logic
                     #
-                    git_repo_tags = [str(tag) for tag in repo.tags]
-                    print(git_repo_tags)
+                    git_repo_tags = [
+                        str(tag)
+                        for tag in repo.tags
+                    ]
+                    print(f"DEBUG: Raw git tags from git repo {git_repo_tags}")
 
                     filter_output = self._filter(git_repo_tags, filter_config)
 
@@ -516,13 +519,16 @@ class Sgit():
                     if not select_output:
                         raise SgitRepoException(f"No git tag could be parsed out with the current repo configuration")
 
+                    print(f"INFO: Attempting to checkout tag '{select_output}' for repo '{name}'")
+
                     # Otherwise atempt to checkout whatever we found. If our selection is still not something valid
                     # inside the git repo, we will get sub exceptions raised by git module.
                     g.checkout(select_output)
 
-                    print(f'INFO: Checked out tag "{select_output}" for repo "{name}"')
+                    print(f"INFO: Checked out tag '{select_output}' for repo '{name}'")
                     print(f"INFO: Current git hash on HEAD: {str(repo.head.commit)}")
-                    print(f"INFO: Current commit summary on HEAD: {str(repo.head.commit.summary)}")
+                    print(f"INFO: Current commit summary on HEAD: ")
+                    print(f"INFO:     {str(repo.head.commit.summary)}")
 
     def _filter(self, sequence, regex_list):
         """
@@ -539,7 +545,7 @@ class Sgit():
         """
         filtered_sequence = []
 
-        print(f"INFO: Running clean step on data")
+        print(f"DEBUG: Running clean step on data")
 
         if not isinstance(regex_list, list):
             raise SgitConfigException(f"sequence for clean step must be a list of items")
@@ -565,7 +571,7 @@ class Sgit():
                 match_result = re.match(filter_regex, item)
 
                 if match_result:
-                    print(f"Clean match result hit: {match_result}")
+                    print(f"DEBUG: Filter match result hit: {match_result}")
 
                     # If the regex contains a group that is what we want to extract out and
                     # add to our filtered output list of results
@@ -576,7 +582,7 @@ class Sgit():
 
                     break
 
-        print(f"INFO: Cleaned items result: {filtered_sequence}")
+        print(f"DEBUG: Filter items result: {filtered_sequence}")
 
         return filtered_sequence
 
@@ -596,7 +602,7 @@ class Sgit():
         ordered_sequence = []
 
         if method == OrderAlgorithms.SEMVER:
-            print(f"INFO: Ordering sequence of items by PEP440 SEMVER logic")
+            print(f"DEBUG: Ordering sequence of items by PEP440 SEMVER logic")
             print(sequence)
 
             ordered_sequence = list(
@@ -609,7 +615,7 @@ class Sgit():
         elif method == OrderAlgorithms.TIME:
             # When sorting by time the latest item in the sequence with the highest or most recent time
             # will be on index[0] in the returned sequence.
-            print(f"INFO: Ordering sequence of items by TIME they wore created, input:")
+            print(f"DEBUG: Ordering sequence of items by TIME they was created, input:")
             print(sequence)
 
             ordered_sequence = list(
@@ -620,7 +626,7 @@ class Sgit():
                 )
             )
         elif method == OrderAlgorithms.ALPHABETICAL:
-            print(f"INFO: Order sequence of items by ALPHABETICAL string order")
+            print(f"DEBUG: Order sequence of items by ALPHABETICAL string order")
             print(sequence)
         else:
             raise SgitConfigException(f"Unsupported ordering algorithm selected")

--- a/sgit/core.py
+++ b/sgit/core.py
@@ -7,20 +7,19 @@ import re
 import sys
 
 # sgit imports
-from sgit.exceptions import SgitException, SgitConfigException, SgitConfigException
+from sgit.constants import *
+from sgit.exceptions import *
 
 # 3rd party imports
 import git
-import ruamel
 import semver
 from git import Repo, Git
 from ruamel import yaml
+from ruamel.yaml import Loader
 
 
 logging.basicConfig(level=logging.INFO)
 log = logging.getLogger(__name__)
-
-DEFAULT_REPO_CONTENT = "repos: { }\n"
 
 
 class Sgit():
@@ -60,7 +59,7 @@ class Sgit():
             sys.exit(1)
 
         with open(self.sgit_config_file_path, "r") as stream:
-            return yaml.load(stream, Loader=ruamel.yaml.Loader)
+            return yaml.load(stream, Loader=Loader)
             # TODO: Minimal required data should be 'repos:'
             #       Raise error if missing from loaded config
 

--- a/sgit/enums.py
+++ b/sgit/enums.py
@@ -1,0 +1,18 @@
+from enum import Enum
+
+
+class OrderAlgorithms(Enum):
+    ALPHABETICAL = 10
+    TIME = 20
+    SEMVER = 30
+
+
+class SelectionMethods(Enum):
+    SEMVER = 10
+    EXACT = 20
+
+
+__all__ = [
+    "OrderAlgorithms",
+    "SelectionMethods",
+]

--- a/sgit/exceptions.py
+++ b/sgit/exceptions.py
@@ -12,3 +12,10 @@ class SgitConfigException(SgitException):
 # we attempt to make an operation on it.
 class SgitRepoException(SgitException):
     pass
+
+
+__all__ = [
+    "SgitException",
+    "SgitConfigException",
+    "SgitRepoException",
+]

--- a/sgit/exceptions.py
+++ b/sgit/exceptions.py
@@ -1,6 +1,14 @@
+# Base exception class for all Sgit related exceptions
 class SgitException(Exception):
     pass
 
 
+# Exceptions that is realted to the ".sgit.yml" config file and the contents in it
 class SgitConfigException(SgitException):
+    pass
+
+
+# Exceptions that happen related to some error with the git repo itself when
+# we attempt to make an operation on it.
+class SgitRepoException(SgitException):
     pass

--- a/tests/test_core_query.py
+++ b/tests/test_core_query.py
@@ -112,6 +112,12 @@ def test_order_semver(sgit):
     ) == ["0.9.0", "1.0.0", "1.1.0"]
 
 
+def test_order_alphabetical(sgit):
+    assert sgit._order(["c", "a", "b"], OrderAlgorithms.ALPHABETICAL) == ["a", "b", "c"]
+    
+    assert sgit._order(["3", "1", "2"], OrderAlgorithms.ALPHABETICAL) == ["1", "2", "3"]
+
+
 def test_select_semver(sgit):
     # Test that basic cases of PEP440 semver checks works as expected when we select that method
     assert sgit._select(

--- a/tests/test_core_query.py
+++ b/tests/test_core_query.py
@@ -124,13 +124,13 @@ def test_select_semver(sgit):
         ["1.1.0", "1.0.0", "0.9.0"],
         ">=1.0.0",
         SelectionMethods.SEMVER,
-    ) == ["1.1.0", "1.0.0"]
+    ) == "1.0.0"
 
     assert sgit._select(
         ["1.1.0", "1.0.0", "0.9.0"],
         "<1.0.0",
         SelectionMethods.SEMVER,
-    ) == ["0.9.0"]
+    ) == "0.9.0"
 
     # Test reserved keywords "first" and "last"
     assert sgit._select(

--- a/tests/test_core_query.py
+++ b/tests/test_core_query.py
@@ -1,0 +1,215 @@
+# -*- coding: utf-8 -*-
+
+# python std lib
+import os
+from datetime import datetime, timedelta
+
+# sgit imports
+from sgit.core import Sgit
+from sgit.constants import *
+from sgit.enums import *
+from sgit.exceptions import *
+
+# 3rd party imports
+import pytest
+from git import Git, Repo
+from ruamel import yaml
+from packaging.version import InvalidVersion
+
+
+def test_filter(sgit):
+    assert sgit._filter([], []) == []
+    assert sgit._filter(["1.0.0"], []) == ["1.0.0"]
+
+    with pytest.raises(SgitConfigException):
+        sgit._filter(["1.0.0"], [""]) == []
+
+    # Test basic failure cases where invalid and wrong values is passed into the method
+    with pytest.raises(SgitConfigException):
+        sgit._filter(None, None)
+
+    with pytest.raises(SgitConfigException):
+        sgit._filter([], None)
+
+    # Wrong values passed into the regex module will cause exceptions
+    with pytest.raises(SgitConfigException):
+        sgit._filter([1], [1])
+
+    assert sgit._filter(["1.0.0"], [r"(1.0)"]) == ["1.0"]
+    assert sgit._filter(["1.0.0"], [r"(1.1)"]) == []
+
+    # With a groupe that is not in the correct place we should not get out anything
+    assert sgit._filter(["v1.0.0"], [r"([0-9].[0-9].[0-9])"]) == []
+
+    # Only the value within the group will remain
+    assert sgit._filter(["v1.0.0"], [r"v([0-9].[0-9].[0-9])"]) == ["1.0.0"]
+
+    # Test valid cleaning with multiple values
+    assert sgit._filter(["v1.0.0", "v2.0.0"], [r"v([0-9].[0-9].[0-9])"]) == ["1.0.0", "2.0.0"]
+
+    # Test two different regex that both filters out the valid values and that extracts out
+    # the version string we want to have
+    assert sgit._filter(
+        ["v1.0.0", "1a.b.c"],
+        [
+            r"[a-z]([0-9].[0-9].[0-9])",
+            r"[0-9]([a-z].[a-z].[a-z])",
+        ],
+    ) == ["1.0.0", "a.b.c"]
+
+
+def test_order_time(sgit):
+    """
+    Ordering by time assumes that we send in the following datastructure into the _order()
+
+    It might be possible to sort on other keys other then datetime object, but when selecting TIME
+    as an option it is assumed that the object should be datetime objects and the result will be reversed before returning
+
+    [(str, datetime_obj), ...]
+    """
+    assert sgit._order(
+        [],
+        OrderAlgorithms.TIME,
+    ) == []
+
+    # We are not able to sort on TIME when items within do not contain any data
+    with pytest.raises(IndexError):
+        sgit._order(
+            [()],
+            OrderAlgorithms.TIME,
+        )
+
+    # Ensure always correct time ordering with offset times
+    c = datetime.now() + timedelta(seconds=1)
+    a = datetime.now() + timedelta(seconds=2)
+    b = datetime.now() + timedelta(seconds=3)
+
+    # Item with datetime b will be after item with datetime a as b was created after a
+    # This will simulate that the latest tag will be put first in the list
+    assert sgit._order(
+        [("1.0.0", a), ("2.0.0", b), ("1.5.0", c)],
+        OrderAlgorithms.TIME,
+    ) == [("1.5.0", c), ("1.0.0", a), ("2.0.0", b)]
+
+    assert sgit._order(
+        [("2.0.0", b), ("1.0.0", a), ("1.5.0", c)],
+        OrderAlgorithms.TIME,
+    ) == [("1.5.0", c), ("1.0.0", a), ("2.0.0", b)]
+
+
+def test_order_semver(sgit):
+    assert sgit._order([], OrderAlgorithms.SEMVER) == []
+
+    # Invalid semver versions should raise exception
+    with pytest.raises(InvalidVersion):
+        sgit._order(["a"], OrderAlgorithms.SEMVER)
+
+    # When sorting by semver, the latest version should be the first item in the list.
+    # By default the semver odering will put the latest version last in the list
+    assert sgit._order(
+        ["0.9.0", "1.0.0", "1.1.0"],
+        OrderAlgorithms.SEMVER,
+    ) == ["0.9.0", "1.0.0", "1.1.0"]
+
+
+def test_select_semver(sgit):
+    # Test that basic cases of PEP440 semver checks works as expected when we select that method
+    assert sgit._select(
+        ["1.1.0", "1.0.0", "0.9.0"],
+        ">=1.0.0",
+        SelectionMethods.SEMVER,
+    ) == ["1.1.0", "1.0.0"]
+
+    assert sgit._select(
+        ["1.1.0", "1.0.0", "0.9.0"],
+        "<1.0.0",
+        SelectionMethods.SEMVER,
+    ) == ["0.9.0"]
+
+    # Test reserved keywords "first" and "last"
+    assert sgit._select(
+        ["1.0.0", "0.9.0"],
+        "last",
+        SelectionMethods.SEMVER,
+    ) == "0.9.0"
+
+    assert sgit._select(
+        ["0.9.0", "1.0.0"],
+        "last",
+        SelectionMethods.SEMVER,
+    ) == "1.0.0"
+
+    assert sgit._select(
+        ["1.0.0", "0.9.0"],
+        "first",
+        SelectionMethods.SEMVER,
+    ) == "1.0.0"
+
+    assert sgit._select(
+        ["0.9.0", "1.0.0"],
+        "first",
+        SelectionMethods.SEMVER,
+    ) == "0.9.0"
+
+
+def test_select_exact(sgit):
+    # Given we want one and one exact value from our list of objects
+    assert sgit._select(
+        ["1.1.0", "1.0.0", "0.9.0"],
+        "1.0.0",
+        SelectionMethods.EXACT,
+    ) == "1.0.0"
+
+    # If we provide a value to select that do not exists we should get None back out
+    assert sgit._select(
+        ["1.1.0", "1.0.0", "0.9.0"],
+        "0.0.0",
+        SelectionMethods.EXACT,
+    ) == None
+
+
+def test_select_failure(sgit):
+    # If we provide a enum value that do not exists and is invalid we should get exception
+    with pytest.raises(SgitConfigException):
+        sgit._select([], "", 123456789)
+
+
+def test_chain(sgit):
+    """
+    This test would match the following working .sgit.yml configuration file
+
+    repos:
+      pykwalify:
+        url: foo
+        revision:
+          tag:
+            filter:"[0-9].[0-9].[0-9]"
+            order: semver
+            select: >=1.8.0
+
+    and if the tags from this git repo still works as expected you should get out the latest
+    git tag from the repo based on semver logic which would be 1.8.0
+    """
+    import random
+    input_sequence = ["1.0.0", "15.10", "18.10", "v0.9.0", "1.8.0"]
+    random.shuffle(input_sequence)
+
+    print(f" -- Input sequence {input_sequence}")
+
+    filter_output = sgit._filter(input_sequence, ["[0-9].[0-9].[0-9]"])
+    print(f" -- Filter output {filter_output}")
+
+    order_output = sgit._order(filter_output, OrderAlgorithms.SEMVER)
+    print(f" -- Order output {order_output}")
+
+    select_output = sgit._select(order_output, "last", SelectionMethods.SEMVER)
+    print(f" -- Select last output {select_output}")
+    assert select_output == "1.8.0"
+
+    select_output = sgit._select(order_output, ">=0.7.0", SelectionMethods.SEMVER)
+    print(f" -- Select >=0.7.0 output {select_output}")
+    assert select_output == "1.8.0"
+
+    select_output = sgit._select(order_output, "<1.5.0", SelectionMethods.SEMVER)
+    print(f" -- Select <1.0.0 output {select_output}")
+    assert select_output == "1.0.0"


### PR DESCRIPTION
Closes #23 

Implement support for specifying "revision.tag=latest" key and support for a few helper options that can be used to filter and clean tags to allow for semver to work it's magic. Please see docs for additional examples and usage of all options.